### PR TITLE
Including zonejs for Angular

### DIFF
--- a/src/root-config-dist.js
+++ b/src/root-config-dist.js
@@ -1,3 +1,6 @@
+// For angular
+import "zone.js";
+
 import { registerAllCoreApplications } from "./root-config-lib";
 import { start } from "single-spa";
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,9 @@ module.exports = {
     },
     disableHostCheck: true
   },
-  externals: ["single-spa"],
+  externals: {
+    "single-spa": "single-spa",
+    "zone.js": "https://unpkg.com/zone.js@0.9.1/dist/zone.js"
+  },
   plugins: []
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = {
   },
   externals: {
     "single-spa": "single-spa",
-    "zone.js": "https://unpkg.com/zone.js@0.9.1/dist/zone.js"
+    "zone.js": "zone.js"
   },
   plugins: []
 };


### PR DESCRIPTION
Angular needs ZoneJS to work, but it's not in the core HTML file. This loads ZoneJS in the root config before anything else is loaded so that Angular code doesn't have to load it itself.